### PR TITLE
Valid or Invalid input tied to record value change and view in etymol…

### DIFF
--- a/src/core/lexicon.py
+++ b/src/core/lexicon.py
@@ -30,7 +30,7 @@ class Word:
         # Check groups for non-conformity
         for group in [x for x in string_set if x]:
             single_consonants = re.match("^[aeiou]?[bcdfghjklmnpqrstvwxyz]{1}[aeiou]?$", group)
-            double_consonants = re.match("(^[aeiou]?(th|st){1}[aeiou]?$)", group)
+            double_consonants = re.match("(^[aeiou]?(th|sh){1}[aeiou]?$)", group)
             if single_consonants is None and double_consonants is None:
                 return False
         return True
@@ -75,7 +75,7 @@ class Word:
 
     def set_field_to(self, field_name: str, new_value: Any) -> None:
         """Sets data for field_name to new_value"""
-        if isinstance(new_garbage_string, str):
+        if isinstance(new_value, str):
             if self.validate_for_field(field_name=field_name, to_validate=new_value) is False:
                 print("Word: Error - Field cannot be set to invalid value.")
                 return

--- a/src/tests/test_lexicon.py
+++ b/src/tests/test_lexicon.py
@@ -3,86 +3,6 @@ import pytest
 from core.lexicon import Lexicon, Word
 
 
-class TestAnEmptyWordShould:
-    """Test operations for an empty Word"""
-    def test__wrd_ist_00__be_able_to_be_instantiated(self):
-        """State Test"""
-        empty_word = Word()
-        assert empty_word
-
-    def test__wrd_ist_01__merges_in_parameter_data(self):
-        """State Test"""
-        init_data = {
-            "translated_word": "NotAWord",
-            "translated_word_components": ["Not", "A", "Word"],
-            "in_language_components": ["Ton", "A", "Drow"],
-            "etymological_symbology": None,
-            "compiled_symbology": None,
-            "symbol_mapping": ["A", "B", "C"],
-            "symbol_selection": ["D", "E", "F"],
-            "symbol_pattern_selected": None,
-            "rules_applied": None,
-            "in_language_word": "TonADrow",
-            "version_history": {"Here": "Today"},
-            "has_been_modified_since_last_resolve": True,  # "Ripple" resolution
-            "has_modified_ancestor": False}
-        word = Word(init_data)
-        for (fieldname, fieldvalue) in init_data.items():
-            assert word.find_data_on(fieldname) == fieldvalue
-
-    def test_return_none_when_validating_for_an_extant_field_with_no_validator(self):
-        """Return - None if the field has no validator."""
-        assert Word().validate_for_field(
-            field_name="translated_word",
-            to_validate="abcde") is None
-
-
-class TestAnEmptyWordValidatingFieldsShould:
-    """Test operations for an empty Word when validating field changes"""
-    def test_return_true_for_with_correct_characters_and_groups(self):
-        """Return - True if the string only contains alphanumeric characters and '|', ']', '['."""
-        assert Word().validate_for_field(
-            "etymological_symbology",
-            "|b|ac|de|ifo|g|h|j|k|l|m|n|p|q|r|s|st|tu|th|v|w|x|y|z[]")
-        # TH WILL FAIL
-
-    def test_return_false_including_invalid_characters_in_valid_groups(self):
-        """Return - False if the string contains non-alphanumeric or non delimeters."""
-        invalid_characters = '!"£$%^&*()_-+={}~#:;@<,>.?\\/'
-        for test_character in invalid_characters:
-            assert Word().validate_for_field(
-                "etymological_symbology",
-                f"|aba|d{test_character}|") is False
-
-    def test_return_false_including_valid_characters_in_invalid_groups(self):
-        """Return - False if the string contains invalid group structures"""
-        invalid_groups = ['a', 'e', 'i', 'o', 'u', 'aa', 'aab', 'aaba', 'aabaa', 'bc']
-        for test_group in invalid_groups:
-            assert Word().validate_for_field(
-                field_name="etymological_symbology",
-                to_validate=f"|{test_group}|") is False
-
-
-class TestAPopulatedWordShould:
-    """Test operations for a Word with populated fields"""
-    def test__wrd_dio_00__return_internal_data_accurately(self):
-        """State Test"""
-        init_data = {
-            "translated_word": "NotAWord",
-            "translated_word_components": ["Not", "A", "Word"],
-            "in_language_components": ["Ton", "A", "Drow"],
-            "symbol_mapping": ["A", "B", "C"],
-            "symbol_selection": ["D", "E", "F"],
-            "in_language_word": "TonADrow",
-            "version_history": {"Here": "Today"},
-            "has_been_modified_since_last_resolve": True,  # "Ripple" resolution
-            "has_modified_ancestor": False}
-        word = Word(init_data)
-        returned_data = word.data_for_export()
-        for (fieldname, fieldvalue) in init_data.items():
-            assert returned_data[fieldname] == fieldvalue
-
-
 class TestAnEmptyLexiconShould:
     """Test operations on an empty Lexicon (0 words)"""
     def test__lex_ist_00__be_able_to_be_instantiated(self):
@@ -267,3 +187,27 @@ class TestAPopulatedLexiconShould:
         for word in read_lexicon.members:
             print(f"Words Unpacked  : {word.find_data_on('translated_word')}")
         assert read_lexicon.get_all_words() == [storeable_word]
+
+    def test__change_etymological_symbology_for_word_with_valid_input(self):
+        """An input of valid characters with valid structure will change the value of the field"""
+        new_lexicon = Lexicon()
+        new_word = Word({"etymological_symbology": "|aba|et|"})
+        new_lexicon.add_entry(new_word)
+        new_lexicon.set_field_to_value("Etymological Symbology", new_word, "|ino|mu|")
+        assert new_lexicon.get_field_for_word("Etymological Symbology", new_word) == "|ino|mu|"
+
+    def test__not_change_etymological_symbology_for_word_with_invalidly_structured_input(self):
+        """An input of valid characters with invalid structure will not change the field value"""
+        new_lexicon = Lexicon()
+        new_word = Word({"etymological_symbology": "|aba|et|"})
+        new_lexicon.add_entry(new_word)
+        new_lexicon.set_field_to_value("Etymological Symbology", new_word, "|inomu|")
+        assert new_lexicon.get_field_for_word("Etymological Symbology", new_word) == "|aba|et|"
+
+    def test__not_change_etymological_symbology_for_word_input_with_invalid_characters(self):
+        """An input of invalid characters with valid structure will not change the field value"""
+        new_lexicon = Lexicon()
+        new_word = Word({"etymological_symbology": "|aba|et|"})
+        new_lexicon.add_entry(new_word)
+        new_lexicon.set_field_to_value("Etymological Symbology", new_word, "|ino!mu|")
+        assert new_lexicon.get_field_for_word("Etymological Symbology", new_word) == "|aba|et|"

--- a/src/tests/test_word.py
+++ b/src/tests/test_word.py
@@ -1,0 +1,103 @@
+"""Tests for a single Word."""
+from core.lexicon import Word
+
+
+class TestAnEmptyWordShould:
+    """Test operations for an empty Word"""
+    def test__wrd_ist_00__be_able_to_be_instantiated(self):
+        """State Test"""
+        empty_word = Word()
+        assert empty_word
+
+    def test__wrd_ist_01__merges_in_parameter_data(self):
+        """State Test"""
+        init_data = {
+            "translated_word": "NotAWord",
+            "translated_word_components": ["Not", "A", "Word"],
+            "in_language_components": ["Ton", "A", "Drow"],
+            "etymological_symbology": None,
+            "compiled_symbology": None,
+            "symbol_mapping": ["A", "B", "C"],
+            "symbol_selection": ["D", "E", "F"],
+            "symbol_pattern_selected": None,
+            "rules_applied": None,
+            "in_language_word": "TonADrow",
+            "version_history": {"Here": "Today"},
+            "has_been_modified_since_last_resolve": True,  # "Ripple" resolution
+            "has_modified_ancestor": False}
+        word = Word(init_data)
+        for (fieldname, fieldvalue) in init_data.items():
+            assert word.find_data_on(fieldname) == fieldvalue
+
+    def test_return_none_when_validating_for_an_extant_field_with_no_validator(self):
+        """Return - None if the field has no validator."""
+        assert Word().validate_for_field(
+            field_name="translated_word",
+            to_validate="abcde") is None
+
+
+class TestAnEmptyWordValidatingFieldsShould:
+    """Test operations for an empty Word when validating field changes"""
+    def test_return_true_for_with_correct_characters_and_groups(self):
+        """Return - True if the string only contains alphanumeric characters and '|', ']', '['."""
+        assert Word().validate_for_field(
+            "etymological_symbology",
+            "|b|ac|de|ifo|g|h|j|k|l|m|n|p|q|r|s|st|tu|th|v|w|x|y|z[]")
+        # TH WILL FAIL
+
+    def test_return_false_including_invalid_characters_in_valid_groups(self):
+        """Return - False if the string contains non-alphanumeric or non delimeters."""
+        invalid_characters = '!"£$%^&*()_-+={}~#:;@<,>.?\\/'
+        for test_character in invalid_characters:
+            assert Word().validate_for_field(
+                "etymological_symbology",
+                f"|aba|d{test_character}|") is False
+
+    def test_return_false_including_valid_characters_in_invalid_groups(self):
+        """Return - False if the string contains invalid group structures"""
+        invalid_groups = ['a', 'e', 'i', 'o', 'u', 'aa', 'aab', 'aaba', 'aabaa', 'bc']
+        for test_group in invalid_groups:
+            assert Word().validate_for_field(
+                field_name="etymological_symbology",
+                to_validate=f"|{test_group}|") is False
+
+
+class TestAPopulatedWordShould:
+    """Test operations for a Word with populated fields"""
+    def test__wrd_dio_00__return_internal_data_accurately(self):
+        """State Test"""
+        init_data = {
+            "translated_word": "NotAWord",
+            "translated_word_components": ["Not", "A", "Word"],
+            "in_language_components": ["Ton", "A", "Drow"],
+            "symbol_mapping": ["A", "B", "C"],
+            "symbol_selection": ["D", "E", "F"],
+            "in_language_word": "TonADrow",
+            "version_history": {"Here": "Today"},
+            "has_been_modified_since_last_resolve": True,  # "Ripple" resolution
+            "has_modified_ancestor": False}
+        word = Word(init_data)
+        returned_data = word.data_for_export()
+        for (fieldname, fieldvalue) in init_data.items():
+            assert returned_data[fieldname] == fieldvalue
+
+    def test__change_etymological_symbology_with_valid_input(self):
+        """An input of valid characters with valid structure will change the value of the field"""
+        init_data = {"etymological_symbology": "|aba|et|"}
+        word = Word(init_data)
+        word.set_field_to("etymological_symbology", "|ino|mu|")
+        assert word.find_data_on("etymological_symbology") == "|ino|mu|"
+
+    def test__not_change_etymological_symbology_with_invalidly_structured_input(self):
+        """An input of valid characters with invalid structure will not change the field value"""
+        init_data = {"etymological_symbology": "|aba|et|"}
+        word = Word(init_data)
+        word.set_field_to("etymological_symbology", "|inomu|")
+        assert word.find_data_on("etymological_symbology") == "|aba|et|"
+
+    def test__not_change_etymological_symbology_for_input_with_invalid_characters(self):
+        """An input of invalid characters with valid structure will not change the field value"""
+        init_data = {"etymological_symbology": "|aba|et|"}
+        word = Word(init_data)
+        word.set_field_to("etymological_symbology", "|ino!mu|")
+        assert word.find_data_on("etymological_symbology") == "|aba|et|"

--- a/src/ui/project_ui.py
+++ b/src/ui/project_ui.py
@@ -147,6 +147,8 @@ class ProjectWindow(QWidget):
                 mapping=self._translated_component_mapping,
                 component_id=this_lexicon.get_field_for_word("Translated Word", associated_word),
                 components=ProjectUIController.clean_and_split_string(target=item.text()))
+        if field_label == "Etymological Symbology":
+            item.setText(this_lexicon.get_field_for_word("Etymological Symbology", associated_word))
 
         self._word_details_table_update()
         self._tree_overview_update()


### PR DESCRIPTION
…ogical symbology

- Word tests moved to its own file
- Tests added to Word and Lexicon to cover valid/invalid input for Etymological Symbology
- Implemented
- All Tests pass