### PR TITLE
Word field changes update Version History.

### DIFF
--- a/src/core/lexicon.py
+++ b/src/core/lexicon.py
@@ -51,7 +51,7 @@ class Word:
             "symbol_pattern_selected": None,
             "rules_applied": None,
             "in_language_word": None,
-            "version_history": None,
+            "version_history": [],
             "has_been_modified_since_last_resolve": None,  # "Ripple" resolution
             "has_modified_ancestor": None}
         if merge_data is not None:
@@ -75,12 +75,24 @@ class Word:
 
     def set_field_to(self, field_name: str, new_value: Any) -> None:
         """Sets data for field_name to new_value"""
+        if self._data[field_name] == new_value:
+            return
+        if field_name == "version_history":
+            return
         if isinstance(new_value, str):
             if self.validate_for_field(field_name=field_name, to_validate=new_value) is False:
                 print("Word: Error - Field cannot be set to invalid value.")
                 return
+        old_value = self._data[field_name]
         self._data[field_name] = new_value
         self._data["has_been_modified_since_last_resolve"] = True
+        self._add_version_history_entry(field_name, old_value, new_value)
+
+    def _add_version_history_entry(self, field_name: str, old_value: Any, new_value: Any):
+        if not self._data["version_history"]:
+            self._data["version_history"] = []
+        log_entry = f"{field_name} FROM {old_value} TO {new_value}"
+        self._data["version_history"].append(log_entry)
 
     def _validate_characters_for_field(self, field_name: str, to_validate: str):
         if field_name not in Word._character_validators:

--- a/src/tests/test_lexicon.py
+++ b/src/tests/test_lexicon.py
@@ -92,6 +92,26 @@ class TestModifyingWordFieldsShould:
         status_after = new_word.find_data_on("has_been_modified_since_last_resolve")
         assert status_after == status_before
 
+    def test__setting_a_field_successfully_adds_to_the_version_history(self):
+        """Version History is longer after a field is successfully set"""
+        new_lexicon = Lexicon()
+        new_word = Word()
+        new_lexicon.add_entry(new_word)
+        history_before = new_word.find_data_on("version_history")
+        new_lexicon.set_field_to_value("etymological_symbology", new_word, "|abu|da|")
+        history_after = new_word.find_data_on("version_history")
+        assert len(history_before) < len(history_after)
+
+    def test__setting_a_field_unsuccessfully_does_not_add_to_the_version_history(self):
+        """Version History is the same length after a field is unsuccessfully set"""
+        new_lexicon = Lexicon()
+        new_word = Word()
+        new_lexicon.add_entry(new_word)
+        history_before = new_word.find_data_on("version_history")
+        new_lexicon.set_field_to_value("etymological_symbology", new_word, "|abu!da|")
+        history_after = new_word.find_data_on("version_history")
+        assert history_before == history_after
+
 
 class TestAPopulatedLexiconShould:
     """Test operations on a lexicon with more than 1 word (1+ words)"""

--- a/src/tests/test_word.py
+++ b/src/tests/test_word.py
@@ -81,6 +81,33 @@ class TestModifyingFieldsShould:
         status_after = new_word.find_data_on("has_been_modified_since_last_resolve")
         assert status_after == status_before
 
+    def test__setting_a_field_successfully_adds_to_the_version_history(self):
+        """Version History is longer after a field is successfully set"""
+        new_word = Word()
+        history_before = new_word.find_data_on("version_history")
+        new_word.set_field_to("etymological_symbology", "|abu|da|")
+        history_after = new_word.find_data_on("version_history")
+        assert len(history_before) < len(history_after)
+
+    def test__setting_a_field_twice_adds_to_the_version_history_each_time(self):
+        """Version History is longer after a field is successfully set"""
+        new_word = Word()
+        original_history = new_word.find_data_on("version_history")[:]
+        new_word.set_field_to("etymological_symbology", "|abu|da|")
+        history_first = new_word.find_data_on("version_history")[:]
+        new_word.set_field_to("etymological_symbology", "|ice|fu|")
+        history_second = new_word.find_data_on("version_history")[:]
+        assert len(original_history) < len(history_first)
+        assert len(history_first) < len(history_second)
+
+    def test__setting_a_field_unsuccessfully_does_not_add_to_the_version_history(self):
+        """Version History is the same length after a field is unsuccessfully set"""
+        new_word = Word()
+        history_before = new_word.find_data_on("version_history")
+        new_word.set_field_to("etymological_symbology", "|abu!da|")
+        history_after = new_word.find_data_on("version_history")
+        assert history_before == history_after
+
 
 class TestAPopulatedWordShould:
     """Test operations for a Word with populated fields"""

--- a/src/ui/project_ui.py
+++ b/src/ui/project_ui.py
@@ -198,10 +198,12 @@ class ProjectWindow(QWidget):
         if self._selected_node:
             this_lexicon: Lexicon = self.options.find_by_id("CurrentLexicon")
             for idx, (col_title, _) in enumerate(self._col_info.items()):
-                item_string = this_lexicon.get_field_for_word(
+                item_data = this_lexicon.get_field_for_word(
                     col_title,
                     self._selected_node)
-                new_item = QStandardItem(item_string)
+                if isinstance(item_data, list):
+                    item_data = "\n".join(item_data)
+                new_item = QStandardItem(item_data)
                 new_item.setData(self._selected_node)
                 word_details_model.setItem(idx, 0, new_item)
 


### PR DESCRIPTION
- Version History is a list of items (at the moment strings)
- Version History is added to when a field value is successfully changed
- Version History is not added to when a field value change is rejected

closes #72